### PR TITLE
remove shells to make nginx the main process of the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ FROM nginx:alpine
 ADD run.sh /run.sh
 ADD default.conf /etc/nginx/conf.d/default.conf
 
-CMD sh run.sh
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -25,4 +25,4 @@ sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/d
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf
 
-nginx -g 'daemon off;'
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
Currently, ```docker top``` shows that the nginx main process is wrapped in two shell processes:

```
/bin/sh -c sh run.sh # created by Docker to wrap the CMD, because it is not specified as an array
sh run.sh # the run.sh script itself, spawning nginx as a child process
```

Because the shell processes don't forward signals to their child processes (i.e. nginx), the container doesn't respond to ```SIGTERM```. That's why ```docker stop``` has to wait for ten seconds and finally terminates the whole thing with ```SIGKILL```.

This PR removes both wrapping shell processes by using the array-form of ```CMD``` and using ```exec``` in ```run.sh``` to replace the script process with nginx.