### PR TITLE
Add SERVER_NAME variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
 ### Environment variables
 
 - `SERVER_REDIRECT` - server to redirect to, eg. `www.example.com`
-- `SERVER_NAME` - optionally define the server name to listen on, useful for capturing regex. eg. `~^www.(?<subdomain>.+).example.com`
+- `SERVER_NAME` - optionally define the server name to listen on, useful for capturing regex variable to use in redirect. eg. `~^www.(?<subdomain>.+).example.com`
 - `SERVER_REDIRECT_PATH` - optionally define path to redirect all requests eg. `/landingpage`
    if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
 ### Environment variables
 
 - `SERVER_REDIRECT` - server to redirect to, eg. `www.example.com`
-- `SERVER_NAME` - optionally define the server name to listen on, useful for capturing variable 
-   to use in SERVER_REDIRECT. eg. `~^www.(?<subdomain>.+).example.com`
+- `SERVER_NAME` - optionally define the server name to listen on eg. `~^www.(?<subdomain>.+).example.com`
+   useful for capturing variable to use in server_redirect. 
 - `SERVER_REDIRECT_PATH` - optionally define path to redirect all requests eg. `/landingpage`
    if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
 ### Environment variables
 
 - `SERVER_REDIRECT` - server to redirect to, eg. `www.example.com`
-- `SERVER_NAME` - optionally define the server name to listen on, eg. `www.example.com`
+- `SERVER_NAME` - optionally define the server name to listen on, useful for capturing regex. eg. `~^www.(?<subdomain>.+).example.com`
 - `SERVER_REDIRECT_PATH` - optionally define path to redirect all requests eg. `/landingpage`
    if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
 ### Environment variables
 
 - `SERVER_REDIRECT` - server to redirect to, eg. `www.example.com`
+- `SERVER_NAME` - optionally define the server name to listen on, eg. `www.example.com`
 - `SERVER_REDIRECT_PATH` - optionally define path to redirect all requests eg. `/landingpage`
    if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
 ### Environment variables
 
 - `SERVER_REDIRECT` - server to redirect to, eg. `www.example.com`
-- `SERVER_NAME` - optionally define the server name to listen on, useful for capturing regex variable to use in redirect. eg. `~^www.(?<subdomain>.+).example.com`
+- `SERVER_NAME` - optionally define the server name to listen on, useful for capturing variable 
+   to use in SERVER_REDIRECT. eg. `~^www.(?<subdomain>.+).example.com`
 - `SERVER_REDIRECT_PATH` - optionally define path to redirect all requests eg. `/landingpage`
    if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 

--- a/default.conf
+++ b/default.conf
@@ -1,6 +1,6 @@
 server {
     listen       80;
-    server_name  localhost;
+    server_name  ${SERVER_NAME};
 
     return ${SERVER_REDIRECT_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
 

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,11 @@ if [ ! -n "$SERVER_REDIRECT" ] ; then
     exit 1
 fi
 
+# set server name from optional ENV var
+if [ ! -n "$SERVER_NAME" ] ; then
+    SERVER_NAME='localhost'
+fi
+
 # set redirect code from optional ENV var
 if [ "$SERVER_REDIRECT_CODE" != '302' ] ; then
     SERVER_REDIRECT_CODE='301'
@@ -21,6 +26,7 @@ if [ ! -n "$SERVER_REDIRECT_SCHEME" ] ; then
 fi
 
 sed -i "s|\${SERVER_REDIRECT}|${SERVER_REDIRECT}|" /etc/nginx/conf.d/default.conf
+sed -i "s|\${SERVER_NAME}|${SERVER_NAME}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
We needed a way to redirect from http://www.subdomain.example.com to https://subdomain.example.com

This adds a variable SERVER_NAME that can be used for capturing a variable from the url and using it in the redirect.

SERVER_NAME: ~^www.(?<subdomain>.+).example.com$
SERVER_REDIRECT: $subdomain.example.com
SERVER_REDIRECT_SCHEME: https