### PR TITLE
allow 301, 302, 303, 307 or 308 as HTTP Status Codes used for redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,18 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
 
 - `SERVER_REDIRECT` - server to redirect to, eg. `www.example.com`
 - `SERVER_NAME` - optionally define the server name to listen on eg. `~^www.(?<subdomain>.+).example.com`
-   useful for capturing variable to use in server_redirect. 
+   - useful for capturing variable to use in server_redirect. 
 - `SERVER_REDIRECT_PATH` - optionally define path to redirect all requests eg. `/landingpage`
-   if not set nginx var `$request_uri` is used
+   - if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 
-   if not set nginx var `$scheme` is used
+   - if not set nginx var `$scheme` is used
 - `SERVER_REDIRECT_CODE` - optionally define the http status code to use for redirection
    - if not set or not in list of allowed codes 301 is used as default
    - allowed Codes are: 301, 302, 303, 307, 308
+ - `SERVER_REDIRECT_POST_CODE` - optionally define the http code to use for POST redirection
+    - useful if client should not change the request method from POST to GET
+    - if not set or not in allowed Codes `SERVER_REDIRECT_CODE` is used
+    - so per default all requests will be redirected with the same status code
 
 See also `docker-compose.yml` file.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
    if not set nginx var `$request_uri` is used
 - `SERVER_REDIRECT_SCHEME` - optionally define scheme to redirect to 
    if not set nginx var `$scheme` is used
-- `SERVER_REDIRECT_CODE` - optionally define the http code to use for redirection
-   if not set nginx 301 - is used
+- `SERVER_REDIRECT_CODE` - optionally define the http status code to use for redirection
+   - if not set or not in list of allowed codes 301 is used as default
+   - allowed Codes are: 301, 302, 303, 307, 308
 
 See also `docker-compose.yml` file.
 

--- a/default.conf
+++ b/default.conf
@@ -2,6 +2,11 @@ server {
     listen       80;
     server_name  ${SERVER_NAME};
 
+    # cherry picked from https://github.com/schmunk42/docker-nginx-redirect/pull/8
+    if ($request_method = POST) {
+        return ${SERVER_REDIRECT_POST_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+    }
+
     return ${SERVER_REDIRECT_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
 
     # redirect server error pages to the static page /50x.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,6 @@ to:
     # optionally define schema to redirect all requests
     # if not set nginx var $scheme is used
     #- SERVER_REDIRECT_SCHEME=https
+    # optionally define the http code to use for redirection
+    # allowed Codes are: 301, 302, 303, 307, 308, default is 301
+    #- SERVER_REDIRECT_CODE=302

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,7 @@ to:
     #- SERVER_REDIRECT_SCHEME=https
     # optionally define the http code to use for redirection
     # allowed Codes are: 301, 302, 303, 307, 308, default is 301
-    #- SERVER_REDIRECT_CODE=302
+    #- SERVER_REDIRECT_CODE=301
+    # optionally define the http code to redirect POST requests
+    # if not set or not in allowed Codes, SERVER_REDIRECT_CODE will be used
+    #- SERVER_REDIRECT_POST_CODE=

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,9 @@ fi
 # allowed Status Codes are: 301, 302, 303, 307, 308
 expr match "$SERVER_REDIRECT_CODE" '30[12378]$' > /dev/null || SERVER_REDIRECT_CODE='301'
 
+# set redirect code from optional ENV var for POST requests
+expr match "$SERVER_REDIRECT_POST_CODE" '30[012378]$' > /dev/null || SERVER_REDIRECT_POST_CODE=$SERVER_REDIRECT_CODE
+
 # set redirect path from optional ENV var
 if [ ! -n "$SERVER_REDIRECT_PATH" ] ; then
     SERVER_REDIRECT_PATH='$request_uri'
@@ -27,6 +30,7 @@ fi
 sed -i "s|\${SERVER_REDIRECT}|${SERVER_REDIRECT}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_NAME}|${SERVER_NAME}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/default.conf
+sed -i "s|\${SERVER_REDIRECT_POST_CODE}|${SERVER_REDIRECT_POST_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf
 

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ fi
 expr match "$SERVER_REDIRECT_CODE" '30[12378]$' > /dev/null || SERVER_REDIRECT_CODE='301'
 
 # set redirect code from optional ENV var for POST requests
-expr match "$SERVER_REDIRECT_POST_CODE" '30[012378]$' > /dev/null || SERVER_REDIRECT_POST_CODE=$SERVER_REDIRECT_CODE
+expr match "$SERVER_REDIRECT_POST_CODE" '30[12378]$' > /dev/null || SERVER_REDIRECT_POST_CODE=$SERVER_REDIRECT_CODE
 
 # set redirect path from optional ENV var
 if [ ! -n "$SERVER_REDIRECT_PATH" ] ; then

--- a/run.sh
+++ b/run.sh
@@ -11,9 +11,8 @@ if [ ! -n "$SERVER_NAME" ] ; then
 fi
 
 # set redirect code from optional ENV var
-if [ "$SERVER_REDIRECT_CODE" != '302' ] ; then
-    SERVER_REDIRECT_CODE='301'
-fi
+# allowed Status Codes are: 301, 302, 303, 307, 308
+expr match "$SERVER_REDIRECT_CODE" '30[12378]$' > /dev/null || SERVER_REDIRECT_CODE='301'
 
 # set redirect path from optional ENV var
 if [ ! -n "$SERVER_REDIRECT_PATH" ] ; then


### PR DESCRIPTION
On the occasion of pull-request #8 I modified the input check for the status code (which was initially added in #5) so that 301, 302, 303, 307 or 308 can now be set via the ENV `SERVER_REDIRECT_CODE`.