### PR TITLE
allow overriding the default access log and error log locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
     - useful if client should not change the request method from POST to GET
     - if not set or not in allowed Codes `SERVER_REDIRECT_CODE` is used
     - so per default all requests will be redirected with the same status code
+- `SERVER_ACCESS_LOG` - optionally define the location where nginx will write its access log
+   - if not set /dev/stdout is used
+- `SERVER_ERROR_LOG` - optionally define the location where nginx will write its error log
+   - if not set /dev/stderr is used
 
 See also `docker-compose.yml` file.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,9 @@ to:
     # optionally define the http code to redirect POST requests
     # if not set or not in allowed Codes, SERVER_REDIRECT_CODE will be used
     #- SERVER_REDIRECT_POST_CODE=
+    # optionally define the location for the nginx access log
+    # if not set /dev/stdout is used
+    #- SERVER_ACCESS_LOG=/dev/null
+    # optionally define the location for the nginx error log
+    # if not set /dev/stderr is used
+    #- SERVER_ERROR_LOG=/dev/null

--- a/run.sh
+++ b/run.sh
@@ -27,11 +27,24 @@ if [ ! -n "$SERVER_REDIRECT_SCHEME" ] ; then
     SERVER_REDIRECT_SCHEME='$scheme'
 fi
 
+# set access log location from optional ENV var
+if [ ! -n "$SERVER_ACCESS_LOG" ] ; then
+    SERVER_ACCESS_LOG='/dev/stdout'
+fi
+
+# set error log location from optional ENV var
+if [ ! -n "$SERVER_ERROR_LOG" ] ; then
+    SERVER_ERROR_LOG='/dev/stderr'
+fi
+
 sed -i "s|\${SERVER_REDIRECT}|${SERVER_REDIRECT}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_NAME}|${SERVER_NAME}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_POST_CODE}|${SERVER_REDIRECT_POST_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf
+
+ln -sfT "$SERVER_ACCESS_LOG" /var/log/nginx/access.log
+ln -sfT "$SERVER_ERROR_LOG" /var/log/nginx/error.log
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
Maybe some people could use the feature added in this PR to save the logs in a volume or pipe them to some other process.

I use it to send log output to ```/dev/null```, because I don't need/want it.

The two default values match the symbolic links present in the nginx base image.