### PR TITLE
Fix to see X-Forwarded-Proto for redirect scheme

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,3 +1,8 @@
+map $http_x_forwarded_proto $redirect_scheme {
+    default $scheme;
+    https https;
+}
+
 server {
     listen       80;
     server_name  ${SERVER_NAME};

--- a/run.sh
+++ b/run.sh
@@ -24,7 +24,7 @@ fi
 
 # set redirect scheme from optional ENV var
 if [ ! -n "$SERVER_REDIRECT_SCHEME" ] ; then
-    SERVER_REDIRECT_SCHEME='$scheme'
+    SERVER_REDIRECT_SCHEME='$redirect_scheme'
 fi
 
 # set access log location from optional ENV var


### PR DESCRIPTION
 I want to use nginx-redirect with [nginx-proxy](https://hub.docker.com/r/jwilder/nginx-proxy/), but nginx-redirect does not see `X-Forwarded-Proto`.
As a result, HTTPS request will be redirected as HTTP request.
![image](https://user-images.githubusercontent.com/1277008/46072687-f9479d80-c1bd-11e8-84af-4415b439a2ff.png)

So I define `$redirect_scheme` in default.conf. And I fixed run.sh to reference `$redirect_scheme`.

### parameter priority

1. SERVER_REDIRECT_SCHEME (environment variable)
1. X-Forwarded-Proto
1. `$scheme`