### PR TITLE
add ${HEALTH_CHECK_URL}

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
    - if not set /dev/stdout is used
 - `SERVER_ERROR_LOG` - optionally define the location where nginx will write its error log
    - if not set /dev/stderr is used
+- 'HEALTH_CHECK_PATH' optionally define the path to answer 200 OK on for external health checks.
+   - Some services like Google Cloud LB requires 200 OK answers to declare a pod healthy.
 
 See also `docker-compose.yml` file.
 

--- a/default.conf
+++ b/default.conf
@@ -7,7 +7,7 @@ server {
     listen       80;
     server_name  ${SERVER_NAME};
 
-    location = /${HEALTH_CHECK_URL} {
+    location = /${HEALTH_CHECK_PATH} {
        return 200 "healthy\n";
     }
 

--- a/default.conf
+++ b/default.conf
@@ -7,9 +7,7 @@ server {
     listen       80;
     server_name  ${SERVER_NAME};
 
-    location = /${HEALTH_CHECK_PATH} {
-       return 200 "healthy\n";
-    }
+    ${HEALTH_CHECK_STANZA}
 
     # cherry picked from https://github.com/schmunk42/docker-nginx-redirect/pull/8
     if ($request_method = POST) {

--- a/default.conf
+++ b/default.conf
@@ -7,12 +7,18 @@ server {
     listen       80;
     server_name  ${SERVER_NAME};
 
+    location = /${HEALTH_CHECK_URL} {
+       return 200 "healthy\n";
+    }
+
     # cherry picked from https://github.com/schmunk42/docker-nginx-redirect/pull/8
     if ($request_method = POST) {
         return ${SERVER_REDIRECT_POST_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
     }
 
-    return ${SERVER_REDIRECT_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+    location / {
+      return ${SERVER_REDIRECT_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+    }
 
     # redirect server error pages to the static page /50x.html
     #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,5 @@ to:
     # if not set /dev/stderr is used
     #- SERVER_ERROR_LOG=/dev/null
     # optionally define the path to answer 200 OK on for external health checks.
-    #- HEALTH_CHECK_PATH=healthz
+    #- HEALTH_CHECK_PATH=/healthz
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,6 @@ to:
     # optionally define the location for the nginx error log
     # if not set /dev/stderr is used
     #- SERVER_ERROR_LOG=/dev/null
+    # optionally define the path to answer 200 OK on for external health checks.
+    #- HEALTH_CHECK_PATH=healthz
+

--- a/run.sh
+++ b/run.sh
@@ -39,7 +39,7 @@ fi
 
 # set endpoint for healthcheck from optional ENV var
 if [ -n "$HEALTH_CHECK_PATH" ] ; then
-    HEALTH_CHECK_STANZA="location = /$HEALTH_CHECK_PATH {\n        return 200 \"healthy\\\n\";\n    }"
+    HEALTH_CHECK_STANZA="location = $HEALTH_CHECK_PATH {\n        return 200 \"healthy\\\n\";\n    }"
 else
     HEALTH_CHECK_STANZA=""
 fi

--- a/run.sh
+++ b/run.sh
@@ -37,12 +37,18 @@ if [ ! -n "$SERVER_ERROR_LOG" ] ; then
     SERVER_ERROR_LOG='/dev/stderr'
 fi
 
+# set endpoint for healthcheck from optional ENV var
+if [ ! -n "$HEALTH_CHECK_URL" ] ; then
+    HEALTH_CHECK_URL='healthz'
+fi
+
 sed -i "s|\${SERVER_REDIRECT}|${SERVER_REDIRECT}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_NAME}|${SERVER_NAME}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_POST_CODE}|${SERVER_REDIRECT_POST_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf
+sed -i "s|\${HEALTH_CHECK_URL}|${HEALTH_CHECK_URL}|" /etc/nginx/conf.d/default.conf
 
 ln -sfT "$SERVER_ACCESS_LOG" /var/log/nginx/access.log
 ln -sfT "$SERVER_ERROR_LOG" /var/log/nginx/error.log

--- a/run.sh
+++ b/run.sh
@@ -38,8 +38,8 @@ if [ ! -n "$SERVER_ERROR_LOG" ] ; then
 fi
 
 # set endpoint for healthcheck from optional ENV var
-if [ ! -n "$HEALTH_CHECK_URL" ] ; then
-    HEALTH_CHECK_URL='healthz'
+if [ ! -n "$HEALTH_CHECK_PATH" ] ; then
+    HEALTH_CHECK_PATH='healthz'
 fi
 
 sed -i "s|\${SERVER_REDIRECT}|${SERVER_REDIRECT}|" /etc/nginx/conf.d/default.conf
@@ -48,7 +48,7 @@ sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/d
 sed -i "s|\${SERVER_REDIRECT_POST_CODE}|${SERVER_REDIRECT_POST_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf
-sed -i "s|\${HEALTH_CHECK_URL}|${HEALTH_CHECK_URL}|" /etc/nginx/conf.d/default.conf
+sed -i "s|\${HEALTH_CHECK_PATH}|${HEALTH_CHECK_PATH}|" /etc/nginx/conf.d/default.conf
 
 ln -sfT "$SERVER_ACCESS_LOG" /var/log/nginx/access.log
 ln -sfT "$SERVER_ERROR_LOG" /var/log/nginx/error.log

--- a/run.sh
+++ b/run.sh
@@ -38,8 +38,10 @@ if [ ! -n "$SERVER_ERROR_LOG" ] ; then
 fi
 
 # set endpoint for healthcheck from optional ENV var
-if [ ! -n "$HEALTH_CHECK_PATH" ] ; then
-    HEALTH_CHECK_PATH='healthz'
+if [ -n "$HEALTH_CHECK_PATH" ] ; then
+    HEALTH_CHECK_STANZA="location = /$HEALTH_CHECK_PATH {\n        return 200 \"healthy\\\n\";\n    }"
+else
+    HEALTH_CHECK_STANZA=""
 fi
 
 sed -i "s|\${SERVER_REDIRECT}|${SERVER_REDIRECT}|" /etc/nginx/conf.d/default.conf
@@ -48,7 +50,7 @@ sed -i "s|\${SERVER_REDIRECT_CODE}|${SERVER_REDIRECT_CODE}|" /etc/nginx/conf.d/d
 sed -i "s|\${SERVER_REDIRECT_POST_CODE}|${SERVER_REDIRECT_POST_CODE}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_PATH}|${SERVER_REDIRECT_PATH}|" /etc/nginx/conf.d/default.conf
 sed -i "s|\${SERVER_REDIRECT_SCHEME}|${SERVER_REDIRECT_SCHEME}|" /etc/nginx/conf.d/default.conf
-sed -i "s|\${HEALTH_CHECK_PATH}|${HEALTH_CHECK_PATH}|" /etc/nginx/conf.d/default.conf
+sed -i "s|\${HEALTH_CHECK_STANZA}|${HEALTH_CHECK_STANZA}|" /etc/nginx/conf.d/default.conf
 
 ln -sfT "$SERVER_ACCESS_LOG" /var/log/nginx/access.log
 ln -sfT "$SERVER_ERROR_LOG" /var/log/nginx/error.log


### PR DESCRIPTION
Google Kubernetes Engine Load Balancer has a limitation in that the health checks need to return 200 OK. So I added a /${HEALTH_CHECK_URL} endpoint.