### PR TITLE
Also listen on container's IPv6 addresses

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -5,6 +5,7 @@ map $http_x_forwarded_proto $redirect_scheme {
 
 server {
     listen       80;
+    listen       [::]:80;
     server_name  ${SERVER_NAME};
 
     # cherry picked from https://github.com/schmunk42/docker-nginx-redirect/pull/8


### PR DESCRIPTION
Currently, docker-nginx-redirect does not handle incoming IPv6 connections.

This is usually not required, mainly because the Docker Userland Proxy maps inbound IPv6 connections to IPv4. However, if the container is part of an IPv6-enabled Docker network and/or the Docker Userland Proxy is disabled, the container must handle IPv6 connections itself.

This PR adds a `listen` directive for all IPv6 addresses. It does not affect containers that don't have any IPv6 addresses.