### PR TITLE
Add healthcheck endpoint, set default ENV in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
 FROM nginx:alpine
 
+ENV SERVER_NAME='localhost' \
+    SERVER_REDIRECT_PATH='$request_uri' \
+    SERVER_REDIRECT_SCHEME='$redirect_scheme' \
+    SERVER_ACCESS_LOG='/dev/stdout' \
+    SERVER_ERROR_LOG='/dev/stderr' \
+    SERVER_HEALTHCHECK_ENABLED=0 \
+    SERVER_HEALTHCHECK_RESPONSE_CODE=200 \
+    SERVER_HEALTHCHECK_RESPONSE_BODY='alive' \
+    SERVER_HEALTHCHECK_PATH='healthcheck'
+
 ADD run.sh /run.sh
 ADD default.conf /etc/nginx/conf.d/default.conf
+ADD healthcheck.conf /etc/nginx/includes/healthcheck.conf
 
 RUN chmod +x /run.sh
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ A very simple container to redirect HTTP traffic to another server, based on `ng
    - if not set /dev/stdout is used
 - `SERVER_ERROR_LOG` - optionally define the location where nginx will write its error log
    - if not set /dev/stderr is used
+- `SERVER_HEALTHCHECK_ENABLED` - optionally enable a static healthcheck endpoint by setting `SERVER_HEALTHCHECK_ENABLED=1`
+   - useful for deploying to Kubernetes or similar infrastructure where readiness needs to be confirmed and monitored
+   - disabled by default
+- `SERVER_HEALTHCHECK_PATH` - optionally override the location of the healthcheck endpoint
+   - defaults to `/healthcheck`
+- `SERVER_HEALTHCHECK_RESPONSE_CODE` - optionally override the status code of the healthcheck endpoint response
+   - defaults to `200`
+- `SERVER_HEALTHCHECK_RESPONSE_BODY` - optionally override the body of the healthcheck endpoint response
+   - defaults to `alive`
 
 See also `docker-compose.yml` file.
 

--- a/default.conf
+++ b/default.conf
@@ -7,16 +7,18 @@ server {
     listen       80;
     server_name  ${SERVER_NAME};
 
-    # cherry picked from https://github.com/schmunk42/docker-nginx-redirect/pull/8
-    if ($request_method = POST) {
-        return ${SERVER_REDIRECT_POST_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
-    }
+    location / {
+        # cherry picked from https://github.com/schmunk42/docker-nginx-redirect/pull/8
+        if ($request_method = POST) {
+            return ${SERVER_REDIRECT_POST_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+        }
 
-    if ($request_method ~ PUT|PATCH|DELETE) {
-        return ${SERVER_REDIRECT_PUT_PATCH_DELETE_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
-    }
+        if ($request_method ~ PUT|PATCH|DELETE) {
+            return ${SERVER_REDIRECT_PUT_PATCH_DELETE_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+        }
 
-    return ${SERVER_REDIRECT_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+        return ${SERVER_REDIRECT_CODE} ${SERVER_REDIRECT_SCHEME}://${SERVER_REDIRECT}${SERVER_REDIRECT_PATH};
+    }
 
     # redirect server error pages to the static page /50x.html
     #
@@ -25,4 +27,5 @@ server {
         root   /usr/share/nginx/html;
     }
 
+    ${HEALTHCHECK_LOCATION_BLOCK}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,5 @@ to:
     # optionally define the location for the nginx error log
     # if not set /dev/stderr is used
     #- SERVER_ERROR_LOG=/dev/null
+    # optionally enable the healthcheck endpoint
+    #- SERVER_HEALTHCHECK_ENABLED=1

--- a/healthcheck.conf
+++ b/healthcheck.conf
@@ -1,0 +1,5 @@
+# return status code 200 on healthcheck route
+location = /${SERVER_HEALTHCHECK_PATH} {
+    return ${SERVER_HEALTHCHECK_RESPONSE_CODE} ${SERVER_HEALTHCHECK_RESPONSE_BODY};
+    add_header Content-Type text/plain;
+}


### PR DESCRIPTION
This pull request adds an optional healthcheck endpoint, useful for environments such as Kubernetes where readiness needs to be probed and monitored.

Four new environment variables are introduced:
- `SERVER_HEALTHCHECK_ENABLED` - optionally enable a static healthcheck endpoint by setting `SERVER_HEALTHCHECK_ENABLED=1`
   - useful for deploying to Kubernetes or similar infrastructure where readiness needs to be confirmed and monitored
   - disabled by default
- `SERVER_HEALTHCHECK_PATH` - optionally override the location of the healthcheck endpoint
   - defaults to `/healthcheck`
- `SERVER_HEALTHCHECK_RESPONSE_CODE` - optionally override the status code of the healthcheck endpoint response
   - defaults to `200`
- `SERVER_HEALTHCHECK_RESPONSE_BODY` - optionally override the body of the healthcheck endpoint response
   - defaults to `alive`

If `SERVER_HEALTHCHECK_ENABLED=1` then `/etc/nginx/includes/healthcheck.conf` is included into `default.conf`.

In order for location matching against `/${SERVER_HEALTHCHECK_PATH}` it was necessary to wrap existing redirects in
```nginx
location / {
    ...
    # Existing redirect directives
    ...
}
```

Finally this pull request tidies up `run.sh` by declaring default ENV values at build time in the Dockerfile.
